### PR TITLE
Adding endpoint yaml for java example

### DIFF
--- a/java/rest-api/.choreo/endpoints.yaml
+++ b/java/rest-api/.choreo/endpoints.yaml
@@ -1,0 +1,22 @@
+# +required Version of the endpoint configuration YAML
+version: 0.1
+
+# +required List of endpoints to create
+endpoints:
+  # +required Unique name for the endpoint. (This name will be used when generating the managed API)
+- name: Product Catalog
+  # +required Numeric port value that gets exposed via this endpoint
+  port: 8080
+  # +required Type of the traffic this endpoint is accepting. Example: REST, GraphQL, etc.
+  # Allowed values: REST, GraphQL, GRPC
+  type: REST
+  # +optional Network level visibility of this endpoint. Defaults to Project
+  # Accepted values: Project|Organization|Public.
+  networkVisibility: Public
+  # +optional Context (base path) of the API that is exposed via this endpoint.
+  # This is mandatory if the endpoint type is set to REST or GraphQL.
+  context: /
+  # +optional Path to the schema definition file. Defaults to wild card route if not provided
+  # This is only applicable to REST endpoint types.
+  # The path should be relative to the docker context.
+  schemaFilePath:  openapi.yaml


### PR DESCRIPTION
## Purpose
> Add endpoint.yaml for java example

## Goals
> Make the example compatible with Choreo's service component type